### PR TITLE
Fix plugin init; fixes #23

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -52,9 +52,7 @@ function plugin_init_geninventorynumber() {
                                  'Peripheral', 'Phone', 'SoftwareLicense'];
 
    $plugin = new Plugin();
-   if ($plugin->isInstalled('geninventorynumber')
-      && $plugin->isActivated('geninventorynumber')
-      && (Session::haveRight("config", CREATE))) {
+   if ($plugin->isActivated('geninventorynumber')) {
       $PLUGIN_HOOKS['use_massive_action']['geninventorynumber'] = 1;
 
       Plugin::registerClass('PluginGeninventorynumberProfile',


### PR DESCRIPTION
Looks like `Session::haveRight("config", CREATE)` cannot work (see https://github.com/glpi-project/glpi/blob/9.4/bugfixes/inc/config.class.php#L87).

I have no idea why it was working before, as this has not changed from version 0.85 of GLPI.