### PR TITLE
fix(generation): Properly decodes the template

### DIFF
--- a/inc/generation.class.php
+++ b/inc/generation.class.php
@@ -39,7 +39,7 @@
 class PluginGeninventorynumberGeneration {
 
    static function autoName($config, CommonDBTM $item) {
-      $template = $config['template'];
+      $template = htmlentities(html_entity_decode($config['template']));
       $len      = strlen($template);
       $suffix = strpos($template, '&lt;');
 

--- a/inc/generation.class.php
+++ b/inc/generation.class.php
@@ -39,7 +39,7 @@
 class PluginGeninventorynumberGeneration {
 
    static function autoName($config, CommonDBTM $item) {
-      $template = htmlentities(html_entity_decode($config['template']));
+      $template = htmlentities(Toolbox::unclean_cross_side_scripting_deep($config['template']));
       $len      = strlen($template);
       $suffix = strpos($template, '&lt;');
 


### PR DESCRIPTION

With GLPI master branch, this plugin no longer works 
because of the treatment on the template

Plugin try to find ```&gt;``` and ```&lt;``` to get the èrealè template
But from GLPI master, ```<``` and ```>``` are encoded like this ```&#60;``` and ```&#62;```

This Pr fix this.