### PR TITLE
Check class existence before creating its config

### DIFF
--- a/inc/configfield.class.php
+++ b/inc/configfield.class.php
@@ -87,7 +87,7 @@ class PluginGeninventorynumberConfigField extends CommonDBChild {
 
       $field = new self();
       foreach ($GENINVENTORYNUMBER_TYPES as $type) {
-         if (!countElementsInTable($table, ['itemtype' => $type])) {
+         if (class_exists($type) && !countElementsInTable($table, ['itemtype' => $type])) {
             $input["plugin_geninventorynumber_configs_id"] = 1;
             $input["itemtype"]                             = $type;
             $input["template"]                             = "&lt;#######&gt;";


### PR DESCRIPTION
Since #39 , the following error occurs in GLPI 9.5.

```
*** PHP Warning (2): call_user_func() expects parameter 1 to be a valid callback, class 'Cable' not found in /var/www/glpi/plugins/geninventorynumber/inc/configfield.class.php at line 127
  Backtrace :
  plugins/geninventorynumber/inc/config.class.php:68 PluginGeninventorynumberConfigField::showForConfig()
  inc/commonglpi.class.php:637                       PluginGeninventorynumberConfig::displayTabContentForItem()
  ajax/common.tabs.php:106                           CommonGLPI::displayStandardTab()
```