### PR TITLE
Fix update check

### DIFF
--- a/inc/generation.class.php
+++ b/inc/generation.class.php
@@ -109,17 +109,12 @@ class PluginGeninventorynumberGeneration {
     * @override CommonDBTM::preItemUpdate
     */
    static function preItemUpdate(CommonDBTM $item) {
-      if (!Session::haveRight("plugin_geninventorynumber", UPDATE)) {
-         return;
-      }
-
-      if (PluginGeninventorynumberConfig::isGenerationActive()
-         && PluginGeninventorynumberConfigField::isActiveForItemType(get_class($item))
-            && !isset($item->input['massiveaction'])) {
-
-         if (isset($item->fields['otherserial'])
-            && isset($item->input['otherserial'])
-               && $item->fields['otherserial'] != $item->input['otherserial']) {
+      $active = PluginGeninventorynumberConfig::isGenerationActive() &&
+          PluginGeninventorynumberConfigField::isActiveForItemType(get_class($item));
+      if ($active && !isset($item->input['massiveaction'])) {
+         if (isset($item->fields['otherserial'], $item->input['otherserial']) &&
+             $item->fields['otherserial'] != $item->input['otherserial']) {
+            // Revert otherserial to previous value
             $item->input['otherserial'] = $item->fields['otherserial'];
             if (!isCommandLine()) {
                Session::addMessageAfterRedirect(


### PR DESCRIPTION
fixes #42

12 years ago, GLPI stopped receiving a return value form pre_item hooks and instead modified the input/fields directly.
6 years ago, the preItemUpdate function removed the return values and previously it was returning `['noright']` if the user did NOT have the plugin's UPDATE right. This cancelled the update (before the change 12 years ago).

I'm not sure the right check make sense. The plugin documentation says that you cannot modify the inventory number for itemtypes managed by this plugin. However, the right check as it was would let everyone without the UPDATE right for the plugin (regenerate) change it. The opposite check makes a bit more sense but doesn't align with the documentation.

Without the check, if the number is managed for that itemtype, nobody can manually change it except through massive action which is what the documentation specifies. It also only cares if the inventory number is changed and not any of the other fields.