### PR TITLE
Auto-reset index

### DIFF
--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -280,9 +280,7 @@ class PluginGeninventorynumberConfig extends CommonDBTM {
          $migration->dropField($table, 'FK_entities');
          $migration->dropField($table, 'entities_id');
          $migration->addField($table, 'date_last_generated', 'timestamp');
-         $migration->addField($table, 'auto_reset_method', 'integer', [
-             'value' => self::AUTO_RESET_NONE
-         ]);
+         $migration->addField($table, 'auto_reset_method', "int unsigned NOT NULL default '0'");
       }
 
       //Remove unused table

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -164,18 +164,17 @@ class PluginGeninventorynumberConfig extends CommonDBTM {
     * @return bool
     */
    static function needIndexReset(): bool {
-       global $DB;
-
        $config = new self();
        $config->getFromDB(1);
 
-       if ($config->fields['auto_reset_method'] === self::AUTO_RESET_NONE) {
+       if (
+           $config->fields['auto_reset_method'] === self::AUTO_RESET_NONE
+           || $config->fields['date_last_generated'] === null
+       ) {
            return false;
        }
+
        $current_date = strtotime($_SESSION['glpi_currenttime']);
-       if ($config->fields['date_last_generated']) {
-           return false;
-       }
        $last_gen_date = strtotime($config->fields['date_last_generated']);
 
        switch ($config->fields['auto_reset_method']) {

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -39,6 +39,27 @@ class PluginGeninventorynumberConfig extends CommonDBTM {
    static $rightname = 'config';
    public $dohistory = true;
 
+   /**
+    * Never reset the index
+    * @var int
+    */
+   public const AUTO_RESET_NONE = 0;
+   /**
+    * Reset the index if the last number was generated on a different day
+    * @var int
+    */
+   public const AUTO_RESET_DAILY = 1;
+   /**
+    * Reset the index if the last number was generated on a different month
+    * @var int
+    */
+   public const AUTO_RESET_MONTHLY = 2;
+   /**
+    * Reset the index if the last number was generated on a different year
+    * @var int
+    */
+   public const AUTO_RESET_YEARLY = 3;
+
    static function getTypeName($nb = 0) {
       return __('Inventory number generation', 'geninventorynumber');
    }
@@ -107,6 +128,19 @@ class PluginGeninventorynumberConfig extends CommonDBTM {
       return $sopt;
    }
 
+    /**
+     * Get all auto-reset options
+     * @return array
+     */
+   public static function getAutoResetOptions(): array {
+       return [
+           self::AUTO_RESET_NONE => __('Never', 'geninventorynumber'),
+           self::AUTO_RESET_DAILY => __('Daily', 'geninventorynumber'),
+           self::AUTO_RESET_MONTHLY => __('Monthly', 'geninventorynumber'),
+           self::AUTO_RESET_YEARLY => __('Yearly', 'geninventorynumber'),
+       ];
+   }
+
    function showForm($id, $options = []) {
       if ($id > 0) {
           $this->getFromDB($id);
@@ -118,14 +152,63 @@ class PluginGeninventorynumberConfig extends CommonDBTM {
 
       $twig = TemplateRenderer::getInstance();
       $twig->display('@geninventorynumber/config.html.twig', [
-         'item'   => $this,
-         'params' => $options,
+         'item'               => $this,
+         'params'             => $options,
+         'auto_reset_methods' => self::getAutoResetOptions(),
       ]);
       return true;
    }
 
+   /**
+    * Check if the index needs to be reset based on the configured auto-reset method
+    * @return bool
+    */
+   static function needIndexReset(): bool {
+       global $DB;
+
+       $config = new self();
+       $config->getFromDB(1);
+
+       if ($config->fields['auto_reset_method'] === self::AUTO_RESET_NONE) {
+           return false;
+       }
+       $current_date = strtotime($_SESSION['glpi_currenttime']);
+       if ($config->fields['date_last_generated']) {
+           return false;
+       }
+       $last_gen_date = strtotime($config->fields['date_last_generated']);
+
+       switch ($config->fields['auto_reset_method']) {
+           case self::AUTO_RESET_DAILY:
+               return date('Y-m-d', $last_gen_date) !== date('Y-m-d', $current_date);
+           case self::AUTO_RESET_MONTHLY:
+               return date('Y-m', $last_gen_date) !== date('Y-m', $current_date);
+           case self::AUTO_RESET_YEARLY:
+               return date('Y', $last_gen_date) !== date('Y', $current_date);
+       }
+       return false;
+   }
+
+   /**
+    * Reset the index to 0 and reset the last generated date
+    */
+   public static function resetIndex(): void {
+       global $DB;
+
+       $DB->update(self::getTable(), [
+           'index' => 0,
+           'date_last_generated' => $_SESSION['glpi_currenttime']
+       ], [
+           'id' => 1
+       ]);
+   }
+
    static function getNextIndex() {
       global $DB;
+
+      if (self::needIndexReset()) {
+          self::resetIndex();
+      }
 
       $query = "SELECT `index`
                 FROM `".getTableForItemType(__CLASS__)."`";
@@ -171,6 +254,8 @@ class PluginGeninventorynumberConfig extends CommonDBTM {
              `is_active` tinyint  NOT NULL default 0,
              `index` int  NOT NULL default 0,
              `comment` text,
+             `date_last_generated` timestamp NULL DEFAULT NULL,
+             `auto_reset_method` int unsigned NOT NULL default '0',
              PRIMARY KEY  (`id`)
              ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;";
          $DB->query($sql) or die($DB->error());
@@ -195,6 +280,10 @@ class PluginGeninventorynumberConfig extends CommonDBTM {
 
          $migration->dropField($table, 'FK_entities');
          $migration->dropField($table, 'entities_id');
+         $migration->addField($table, 'date_last_generated', 'timestamp');
+         $migration->addField($table, 'auto_reset_method', 'integer', [
+             'value' => self::AUTO_RESET_NONE
+         ]);
       }
 
       //Remove unused table
@@ -212,7 +301,8 @@ class PluginGeninventorynumberConfig extends CommonDBTM {
       global $DB;
 
       $query = "UPDATE `".getTableForItemType(__CLASS__)."`
-                SET `index`=`index`+1";
+                SET `index`=`index`+1,`date_last_generated`='{$_SESSION['glpi_currenttime']}'
+                WHERE `is_active`='1'";
       $DB->query($query);
    }
 

--- a/inc/configfield.class.php
+++ b/inc/configfield.class.php
@@ -129,7 +129,7 @@ class PluginGeninventorynumberConfigField extends CommonDBChild {
       echo "</th><th>" . __('Active') . "</th>";
       echo "<th>" . __('Use global index', 'geninventorynumber') . "</th>";
       echo "<th>" . __('Index position', 'geninventorynumber') . "</th>";
-      echo "<th>" . __('Auto-reset method', 'geninventorynumber') . "</th></tr></thead>";
+      echo "<th>" . __('Index auto-reset method', 'geninventorynumber') . "</th></tr></thead>";
 
       echo "<tbody>";
       $rows = getAllDataFromTable(getTableForItemType(__CLASS__));

--- a/inc/configfield.class.php
+++ b/inc/configfield.class.php
@@ -90,9 +90,7 @@ class PluginGeninventorynumberConfigField extends CommonDBChild {
          $migration->changeField($table, 'enabled', 'is_active', 'boolean');
          $migration->changeField($table, 'use_index', 'use_index', 'boolean');
           $migration->addField($table, 'date_last_generated', 'timestamp');
-         $migration->addField($table, 'auto_reset_method', 'integer', [
-             'value' => PluginGeninventorynumberConfig::AUTO_RESET_NONE
-         ]);
+         $migration->addField($table, 'auto_reset_method', "int unsigned NOT NULL default '0'");
          $migration->migrationOneTable($table);
       }
 

--- a/inc/configfield.class.php
+++ b/inc/configfield.class.php
@@ -233,13 +233,14 @@ class PluginGeninventorynumberConfigField extends CommonDBChild {
        ]);
        if ($iterator->count() > 0) {
            $data = $iterator->current();
-           if ($data['auto_reset_method'] === PluginGeninventorynumberConfig::AUTO_RESET_NONE) {
+           if (
+               $data['auto_reset_method'] === PluginGeninventorynumberConfig::AUTO_RESET_NONE
+               || $data['date_last_generated'] === null
+           ) {
                return false;
            }
+
            $current_date = strtotime($_SESSION['glpi_currenttime']);
-           if ($data['date_last_generated'] === null) {
-               return false;
-           }
            $last_gen_date = strtotime($data['date_last_generated']);
 
            switch ($data['auto_reset_method']) {

--- a/inc/configfield.class.php
+++ b/inc/configfield.class.php
@@ -128,8 +128,8 @@ class PluginGeninventorynumberConfigField extends CommonDBChild {
       echo "<tr><th colspan='2'>" . __('Generation templates', 'geninventorynumber');
       echo "</th><th>" . __('Active') . "</th>";
       echo "<th>" . __('Use global index', 'geninventorynumber') . "</th>";
-      echo "<th colspan='2'>" . __('Index position', 'geninventorynumber') . "</th>";
-      echo "<th colspan='2'>" . __('Auto-reset method', 'geninventorynumber') . "</th></tr></thead>";
+      echo "<th>" . __('Index position', 'geninventorynumber') . "</th>";
+      echo "<th>" . __('Auto-reset method', 'geninventorynumber') . "</th></tr></thead>";
 
       echo "<tbody>";
       $rows = getAllDataFromTable(getTableForItemType(__CLASS__));
@@ -147,13 +147,13 @@ class PluginGeninventorynumberConfigField extends CommonDBChild {
          echo "<td class='tab_bg_1' align='center'>";
          Dropdown::showYesNo("ids[$itemtype][use_index]", $data["use_index"]);
          echo "</td>";
-         echo "<td class='tab_bg_1' colspan='2' align='center'>";
+         echo "<td class='tab_bg_1' align='center'>";
          if ($data["is_active"] && !$data["use_index"]) {
             echo "<input type='text' name='ids[$itemtype][index]' value='" .
                 $data['index'] . "' size='12'>";
          }
          echo "</td>";
-         echo "<td class='tab_bg_1' colspan='2' align='center'>";
+         echo "<td class='tab_bg_1' align='center'>";
          if ($data["is_active"] && !$data["use_index"]) {
              Dropdown::showFromArray("ids[$itemtype][auto_reset_method]", PluginGeninventorynumberConfig::getAutoResetOptions(), [
                  'value' => $data['auto_reset_method'] ?? 0
@@ -163,7 +163,7 @@ class PluginGeninventorynumberConfigField extends CommonDBChild {
          echo "</tr>";
       }
 
-      echo "<tr class='tab_bg_1'><td align='center' colspan='5'>";
+      echo "<tr class='tab_bg_1'><td align='center' colspan='6'>";
       echo "<input type='submit' name='update_fields' value=\"" . _sx('button', 'Save') . "\" class='submit'>";
       echo "</td></tr>";
 

--- a/inc/generation.class.php
+++ b/inc/generation.class.php
@@ -105,9 +105,9 @@ class PluginGeninventorynumberGeneration {
             }
 
             if ($config['use_index']) {
-               PluginGeninventorynumberConfig::updateIndex();
+               PluginGeninventorynumberConfig::updateIndex($item->input['otherserial']);
             } else {
-               PluginGeninventorynumberConfigField::updateIndex(get_class($item));
+               PluginGeninventorynumberConfigField::updateIndex(get_class($item), $item->input['otherserial']);
             }
          }
       }

--- a/inc/generation.class.php
+++ b/inc/generation.class.php
@@ -105,9 +105,9 @@ class PluginGeninventorynumberGeneration {
             }
 
             if ($config['use_index']) {
-               PluginGeninventorynumberConfig::updateIndex($item->input['otherserial']);
+               PluginGeninventorynumberConfig::updateIndex();
             } else {
-               PluginGeninventorynumberConfigField::updateIndex(get_class($item), $item->input['otherserial']);
+               PluginGeninventorynumberConfigField::updateIndex(get_class($item));
             }
          }
       }

--- a/templates/config.html.twig
+++ b/templates/config.html.twig
@@ -56,7 +56,7 @@
         'auto_reset_method',
         item.fields['auto_reset_method'] ?? 0,
         auto_reset_methods,
-        __('Global auto-reset method', 'geninventorynumber')
+        __('Index auto-reset method', 'geninventorynumber')
     ) }}
     {{ fields.nullField() }}
 

--- a/templates/config.html.twig
+++ b/templates/config.html.twig
@@ -52,6 +52,14 @@
     ) }}
     {{ fields.nullField() }}
 
+    {{ fields.dropdownArrayField(
+        'auto_reset_method',
+        item.fields['auto_reset_method'] ?? 0,
+        auto_reset_methods,
+        __('Global auto-reset method', 'geninventorynumber')
+    ) }}
+    {{ fields.nullField() }}
+
     {{ fields.textareaField(
         'comment',
         item.fields['comment'],


### PR DESCRIPTION
Based on #41 for GLPI 10 compatibility.

Adds a new "Auto-reset method" for itemtype-based and global indexes. This option is intended to be used when templates include date-related tags such as:
```
<\Y####>
```
You can then set the auto-reset method to Yearly to have the index reset to 0 every year to get:
```
20210001
20210002
20220001
```

Current auto-reset options added:
- Never (Default)
- Daily
- Monthly
- Yearly