### PR TITLE
Update generation.class.php

### DIFF
--- a/inc/generation.class.php
+++ b/inc/generation.class.php
@@ -57,7 +57,7 @@ class PluginGeninventorynumberGeneration {
           . '/';
       $matches = [];
       if (preg_match($pattern, $template, $matches) !== 1) {
-         return $template;
+         return $config['template']; // Return verbatim value
       }
 
       $prefix  = $matches['prefix'];

--- a/inc/generation.class.php
+++ b/inc/generation.class.php
@@ -45,7 +45,7 @@ class PluginGeninventorynumberGeneration {
       $template = Sanitizer::unsanitize($config['template']);
 
       $matches = [];
-      if (preg_match('/^(?<prefix>.*)<(?<autonum>[^<#]*(?<mask>#{1,10})[^#>]*)>(?<suffix>.*)$/', $template, $matches) !== 1) {
+      if (preg_match('/^(?<prefix>.*)<(?<autonum>[^<#>]*(?<mask>#{1,10})[^<#>]*)>(?<suffix>.*)$/', $template, $matches) !== 1) {
          return $template;
       }
 

--- a/inc/generation.class.php
+++ b/inc/generation.class.php
@@ -44,8 +44,19 @@ class PluginGeninventorynumberGeneration {
 
       $template = Sanitizer::unsanitize($config['template']);
 
+      $pattern = '/'
+          . '^(?<prefix>.*)'    // capture every char located before the "autonum" part
+          . '<'                 // "<" char that indicates beginning of the "autonum" part
+          . '(?<autonum>'
+          . '.*?'               // capture chars located before the # mask part (lazy ? quantifier prevent inclusion of < in "autonum" part)
+          . '#{1,10}'           // # mask part
+          . '.*?'               // capture chars located after the # mask part (lazy ? quantifier prevent inclusion of > in "autonum" part)
+          . ')'
+          . '>'                 // ">" char that indicates ending the "autonum" part
+          . '(?<suffix>.*)$'    // capture every char located after the "autonum" part
+          . '/';
       $matches = [];
-      if (preg_match('/^(?<prefix>.*)<(?<autonum>.*?#{1,10}.*?)>(?<suffix>.*)$/', $template, $matches) !== 1) {
+      if (preg_match($pattern, $template, $matches) !== 1) {
          return $template;
       }
 

--- a/inc/generation.class.php
+++ b/inc/generation.class.php
@@ -45,14 +45,24 @@ class PluginGeninventorynumberGeneration {
       $template = Sanitizer::unsanitize($config['template']);
 
       $matches = [];
-      if (preg_match('/^(?<prefix>.*)<(?<autonum>[^<#>]*(?<mask>#{1,10})[^<#>]*)>(?<suffix>.*)$/', $template, $matches) !== 1) {
+      if (preg_match('/^(?<prefix>.*)<(?<autonum>.*?#{1,10}.*?)>(?<suffix>.*)$/', $template, $matches) !== 1) {
          return $template;
       }
 
       $prefix  = $matches['prefix'];
       $autonum = $matches['autonum'];
-      $mask    = $matches['mask'];
       $suffix  = $matches['suffix'];
+
+      // Find # mask length.
+      // autonum par may contains # at multiple places, for instance <#\Y-\m-\d_######>, so we try to find
+      // the longer "#" suite.
+      $mask = null;
+      for ($i = 10; $i > 0; $i--) {
+          $mask = str_repeat('#', $i);
+          if (str_contains($autonum, str_repeat('#', $i))) {
+              break;
+          }
+      }
 
       $numero = $config['use_index']
          ? PluginGeninventorynumberConfig::getNextIndex()

--- a/inc/generation.class.php
+++ b/inc/generation.class.php
@@ -45,11 +45,13 @@ class PluginGeninventorynumberGeneration {
       $template = Sanitizer::unsanitize($config['template']);
 
       $matches = [];
-      if (preg_match('/^<[^#]*(#{1,10})[^#]*>$/', $template, $matches) !== 1) {
+      if (preg_match('/[^<]*<[^#]*(#{1,10})[^#]*>$/', $template, $matches) !== 1) {
          return $template;
       }
 
-      $autoNum = Toolbox::substr($template, 1, Toolbox::strlen($template) - 2);
+      $suffixPosition = strpos($template, '<');
+      $prefix = substr($template, 0, $suffixPosition);
+      $autoNum = Toolbox::substr($template, $suffixPosition + 1, Toolbox::strlen($template) - $suffixPosition - 2);
       $mask    = $matches[1];
 
       $autoNum = str_replace(
@@ -78,7 +80,8 @@ class PluginGeninventorynumberGeneration {
       }
 
       $template = str_replace($mask, Toolbox::str_pad($newNo, $len, '0', STR_PAD_LEFT), $autoNum);
-
+      $template = $prefix . $template;
+      
       return Sanitizer::sanitize($template);
    }
 

--- a/inc/generation.class.php
+++ b/inc/generation.class.php
@@ -49,9 +49,9 @@ class PluginGeninventorynumberGeneration {
          return $template;
       }
 
-      $suffixPosition = strpos($template, '<');
-      $prefix = substr($template, 0, $suffixPosition);
-      $autoNum = Toolbox::substr($template, $suffixPosition + 1, Toolbox::strlen($template) - $suffixPosition - 2);
+      $maskPosition = strpos($template, '<');
+      $prefix = substr($template, 0, $maskPosition);
+      $autoNum = Toolbox::substr($template, $maskPosition + 1, Toolbox::strlen($template) - $maskPosition - 2);
       $mask    = $matches[1];
 
       $autoNum = str_replace(


### PR DESCRIPTION
Prefixing inventory numbers by some text was removed in version 2.6.
People trying to migrate from GLPI 9.5 to GLPI 10 will create text strings instead of real inventory numbers.
The proposed modification reenables the previous feature...