### PR TITLE
Init date_last_generated on install

### DIFF
--- a/inc/configfield.class.php
+++ b/inc/configfield.class.php
@@ -106,14 +106,17 @@ class PluginGeninventorynumberConfigField extends CommonDBChild {
          }
 
          // Init date_last_generated
-         if (countElementsInTable($type::getTable())) {
+         $cfield = new self();
+         if (
+             $cfield->getFromDBByCrit(['itemtype' => $type])
+             && $cfield->fields['date_last_generated'] === null
+             && countElementsInTable($type::getTable())
+         ) {
             $max = $DB->request([
                'SELECT' => ['MAX' => 'date_creation as date'],
                'FROM' => $type::getTable()
             ])->current()['date'];
 
-            $cfield = new self();
-            $cfield->getFromDBByCrit(['itemtype' => $type]);
             $cfield->update([
                'id' => $cfield->getID(),
                'date_last_generated' => $max

--- a/inc/configfield.class.php
+++ b/inc/configfield.class.php
@@ -89,7 +89,7 @@ class PluginGeninventorynumberConfigField extends CommonDBChild {
          }
          $migration->changeField($table, 'enabled', 'is_active', 'boolean');
          $migration->changeField($table, 'use_index', 'use_index', 'boolean');
-          $migration->addField($table, 'date_last_generated', 'timestamp');
+         $migration->addField($table, 'date_last_generated', 'timestamp');
          $migration->addField($table, 'auto_reset_method', "int unsigned NOT NULL default '0'");
          $migration->migrationOneTable($table);
       }
@@ -103,6 +103,21 @@ class PluginGeninventorynumberConfigField extends CommonDBChild {
             $input["is_active"]                            = 0;
             $input["index"]                                = 0;
             $field->add($input);
+         }
+
+         // Init date_last_generated
+         if (countElementsInTable($type::getTable())) {
+            $max = $DB->request([
+               'SELECT' => ['MAX' => 'date_creation as date'],
+               'FROM' => $type::getTable()
+            ])->current()['date'];
+
+            $cfield = new self();
+            $cfield->getFromDBByCrit(['itemtype' => $type]);
+            $cfield->update([
+               'id' => $cfield->getID(),
+               'date_last_generated' => $max
+            ]);
          }
       }
    }


### PR DESCRIPTION
Field `date_last_generated` added in #49 should be initialized on install/update.

If it is not, it will only be initialized on the first asset (for each types) created after updating to 2.8.0, which mean this asset wont have its index reset even if it was created a day/month/year later than the previous asset.