### PR TITLE
Fix undefined index `is_active`

### DIFF
--- a/inc/configfield.class.php
+++ b/inc/configfield.class.php
@@ -193,7 +193,8 @@ class PluginGeninventorynumberConfigField extends CommonDBChild {
    public function prepareInputForAdd($input)
    {
        $input = parent::prepareInputForAdd($input);
-       if (!$input["is_active"] || $input["use_index"]) {
+       $check_auto_reset = isset($input['is_active']) && isset($input['use_index']);
+       if ($check_auto_reset && (!$input["is_active"] || $input["use_index"]) {
            $input['auto_reset_method'] = 0;
        }
        return $input;
@@ -202,7 +203,8 @@ class PluginGeninventorynumberConfigField extends CommonDBChild {
    public function prepareInputForUpdate($input)
    {
        $input = parent::prepareInputForUpdate($input);
-       if (!$input["is_active"] || $input["use_index"]) {
+       $check_auto_reset = isset($input['is_active']) && isset($input['use_index']);
+       if ($check_auto_reset && (!$input["is_active"] || $input["use_index"])) {
            $input['auto_reset_method'] = 0;
        }
        return $input;

--- a/inc/configfield.class.php
+++ b/inc/configfield.class.php
@@ -117,7 +117,7 @@ class PluginGeninventorynumberConfigField extends CommonDBChild {
                'FROM' => $type::getTable()
             ])->current()['date'];
 
-            $cfield->update([
+            $DB->update($cfield::getTable(), [
                'id' => $cfield->getID(),
                'date_last_generated' => $max
             ]);


### PR DESCRIPTION
Fix the following warnings when updating the plugin, as #67 will trigger this code without these two required keys.

```
Traitement du plugin « geninventorynumber »...
PHP Notice:  Undefined index: is_active in /var/www/html/glpi/marketplace/geninventorynumber/inc/configfield.class.php on line 201
PHP Notice:  Undefined index: is_active in /var/www/html/glpi/marketplace/geninventorynumber/inc/configfield.class.php on line 201
PHP Notice:  Undefined index: is_active in /var/www/html/glpi/marketplace/geninventorynumber/inc/configfield.class.php on line 201
PHP Notice:  Undefined index: is_active in /var/www/html/glpi/marketplace/geninventorynumber/inc/configfield.class.php on line 201
PHP Notice:  Undefined index: is_active in /var/www/html/glpi/marketplace/geninventorynumber/inc/configfield.class.php on line 201
PHP Notice:  Undefined index: is_active in /var/www/html/glpi/marketplace/geninventorynumber/inc/configfield.class.php on line 201
PHP Notice:  Undefined index: is_active in /var/www/html/glpi/marketplace/geninventorynumber/inc/configfield.class.php on line 201
PHP Notice:  Undefined index: is_active in /var/www/html/glpi/marketplace/geninventorynumber/inc/configfield.class.php on line 201
PHP Notice:  Undefined index: is_active in /var/www/html/glpi/marketplace/geninventorynumber/inc/configfield.class.php on line 201
PHP Notice:  Undefined index: is_active in /var/www/html/glpi/marketplace/geninventorynumber/inc/configfield.class.php on line 201
Le plugin « geninventorynumber » a été installé et peut être activé.
Traitement du plugin « geninventorynumber »...
Le plugin « geninventorynumber » a été activé.
```