### PR TITLE
Fix \s and \n placeholders for datainjection

### DIFF
--- a/inc/generation.class.php
+++ b/inc/generation.class.php
@@ -95,8 +95,8 @@ class PluginGeninventorynumberGeneration {
             date('Y'),
             date('m'),
             date('d'),
-            $item->fields['serial'] ?? '',
-            $item->fields['name'] ?? '',
+            $item->input['serial'] ?? '',
+            $item->input['name'] ?? '',
             '',
          ],
          $autonum

--- a/inc/generation.class.php
+++ b/inc/generation.class.php
@@ -95,8 +95,8 @@ class PluginGeninventorynumberGeneration {
             date('Y'),
             date('m'),
             date('d'),
-            $item->input['serial'] ?? '',
-            $item->input['name'] ?? '',
+            $item->input['serial'] ?? $item->fields['serial'] ?? '',
+            $item->input['name'] ?? $item->fields['name'] ?? '',
             '',
          ],
          $autonum


### PR DESCRIPTION
Using `$this->fields` to read the current serial number and name isn't reliable.

I didn't realize this at first because the fields are set when creating a computer from a form.
This is done indirectly when checking rights:
![image](https://user-images.githubusercontent.com/42734840/194859635-6062d041-28e6-498e-9f81-7810e0e9971e.png)

Adding a computer "from the code" (e.g. with datainjection) will result in an empty `$this->fields` array.
Fixed by switching to `$this->input`, which is filled in this case.